### PR TITLE
tolerate whitespace after drawer block start

### DIFF
--- a/lib/org-mode-parser.js
+++ b/lib/org-mode-parser.js
@@ -229,7 +229,7 @@ var parseBigString=function (data){
     var deadlineRE=/DEADLINE:\s*<(\d+)\-(\d+)\-(\d+)/;
     var closedRE=/CLOSED:\s*<(\d+)\-(\d+)\-(\d+)\s*\w+/;
 
-    var drawerFinderRE=/\s*:([a-zA-Z_0-9]+):$/;
+    var drawerFinderRE=/\s*:([a-zA-Z_0-9]+):\s*$/;
     var property_startRE=/\s*:PROPERTIES:/;
     var drawerENDRE=/\s*:END:/;
     var singlePropertyMatcherRE=/^\s*:(.*?):\s*(.*?)\s*$/;


### PR DESCRIPTION
Permit some white space after the block eg: `':DRAWER:   '`